### PR TITLE
feat: Add password authentication for Redis connection

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -1109,6 +1109,10 @@ class Telegram
         self::$redis_connection = new \Redis();
         self::$redis_connection->connect($config['host'], $config['port']);
 
+        if (!empty($config['password'])) {
+            self::$redis_connection->auth($config['password']);
+        }
+
         return $this;
     }
 


### PR DESCRIPTION
This change adds support for password authentication when connecting to a Redis server. The `enableRedis` method now checks for a 'password' in the config array and uses it to authenticate if provided.

<!--
Important:
If this pull request is not related to any issue and contains a new feature, please create an issue first for discussion.
https://github.com/php-telegram-bot/core/issues/new?template=Feature_Request.md

Make sure this pull request is pointed towards the "develop" branch and refers to any issue that it's related to!
-->

<!-- Fill in the relevant information below to help triage your pull request. -->

| ?            |  !
|---           | ---
| Type         | bug / feature / improvement
| BC Break     | yes / no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary of your change. -->
